### PR TITLE
Don't submit unnamed form without any data on non POST request.

### DIFF
--- a/src/CoreShop/Bundle/ResourceBundle/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -62,6 +62,10 @@ final class HttpFoundationRequestHandler extends \Symfony\Component\Form\Extensi
         if ('GET' === $method || 'HEAD' === $method || 'TRACE' === $method) {
             if ('' === $name) {
                 $data = $request->query->all();
+                // No data - nothing to submit.
+                if (!count($data)) {
+                    return;
+                }
             } else {
                 // Don't submit GET requests if the form's name does not exist
                 // in the request


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | Don't know
| Deprecations? | no

I've no idea why the METHOD check of the original Smyonfy code should be removed and there's not documentation I've found which would explain why that is done or how it is supposed to work with other components.
I just got the bundle as a dependency of the dpfaffenbauer/process-manager package I installed. And now this dependency is interfering with _all_ our forms.
Most obvious issue so far is that due the permanent form submits the CSRF Token validation is triggered even on actual non-submissions, leading to bogus CSRF errors on our forms without user interaction.

Now given there's a name check for named forms in order to determine if a submission is suitable I think the least thing to do for unnamed forms is to check whether there's any data at all before just submitting empty data.
An extended approach would be to check if there are matching parameters for the form fields before triggering a submit.
Maybe something like <code>!empty(array_intersect_key($data, $form->all()))</code> as check could do - however, this would be more restrictive than the original Symfony handler and hence could lead to more trouble.